### PR TITLE
Switch to using abstract-cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
   },
   "homepage": "https://github.com/fastify/fastify-caching#readme",
   "devDependencies": {
-    "fastify": "^0.33.0",
+    "fastify": "^0.35.2",
     "pre-commit": "^1.2.2",
     "snazzy": "^7.0.0",
     "standard": "^10.0.3",
     "tap": "^10.7.3"
   },
   "dependencies": {
-    "@jsumners/memcache": "^2.1.0",
+    "abstract-cache": "^1.0.0",
     "fastify-plugin": "^0.1.1",
     "uid-safe": "^2.1.5"
   }

--- a/plugin.js
+++ b/plugin.js
@@ -5,7 +5,7 @@ const uidSafe = require('uid-safe')
 const defaultOptions = {
   expiresIn: undefined,
   privacy: undefined,
-  cache: require('@jsumners/memcache')('fastify-caching'),
+  cache: require('abstract-cache')(),
   cacheSegment: 'fastify-caching'
 }
 


### PR DESCRIPTION
This PR switches out the requirement for Catbox style caches with a requirement for [abstract-cache](https://github.com/jsumners/abstract-cache) style caches. This allows greater flexibility due to the fact that `abstract-cache` allows re-using established connections. So, for example, the user could register multiple instances of `fastify-caching` for different routes while using the same connection:

```js
const redis = require('ioredis')({host: '127.0.0.1'})
const abcache = require('abstract-cache')({
  driver: {
    name: 'abstract-cache-redis',
    options: {client: redis}
  }
})

const fastify = require('fastify')()
const fastifyCaching = require('fastify-caching')

fastify.register((instance, opts, next) => {
  instance.register(fastifyCaching, {
    segment: 'foo',
    cache: abcache
  })

  instance.get('/foo', async function (req, reply) {
    await this.cache.set('foo', 'foo', 1000) // goes to the 'foo' Redis collection
    return {foo: 'foo'}
  })

  next()
})

fastify.register((instance, opts, next) => {
  instance.register(fastifyCaching, {
    segment: 'bar',
    cache: abcache
  })

  instance.get('/bar', async function (req, reply) {
    await this.cache.set('bar', 'bar', 1000) // goes to the 'bar' Redis collection
    return {bar: 'bar'}
  })

  next()
})
```