### PR TITLE
next callback should use the response payload

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -48,7 +48,7 @@ function etagOnSend (req, res, payload, next) {
     { id: etag, segment: this.cacheSegment },
     true,
     res._etagLife,
-    next
+    (err) => next(err, payload)
   )
 }
 


### PR DESCRIPTION
Hi there,

I had a similar behavior to #19 : 
by using `reply.etag()` the response payload seemed to be replaced by the cache payload, 
when investigating, I found that a `next` callback in the `onSend` hook was given the cache payload instead of the response one.

So here is the PR that fixes #19 .

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
