### PR TITLE
next callback should use the response payload

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -48,7 +48,7 @@ function etagOnSend (req, res, payload, next) {
     { id: etag, segment: this.cacheSegment },
     true,
     res._etagLife,
-    next
+    (err) => next(err, payload)
   )
 }
 


### PR DESCRIPTION
This PR was already made some time ago #34, but was rejected due to a missing test.

When using `reply.etag()` the `etagOnSend` hook uses the cache payload, instead of the response payload.

I have added a test that checks whether the correct payload is returned.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
