### PR TITLE
Moving towards 100% coverage #60

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,1 +1,0 @@
-check-coverage: false

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -65,6 +65,56 @@ test('cache is usable', (t) => {
   })
 })
 
+test('getting cache item with error returns error', (t) => {
+  t.plan(1)
+  const mockCache = {
+    get: (info, callback) => callback(new Error('cache.get always errors')),
+    set: (key, value, ttl, callback) => callback()
+  }
+
+  const instance = fastify()
+  instance.register(plugin, { cache: mockCache })
+
+  instance.get('/one', (req, reply) => {
+    instance.cache.set('one', { one: true }, 1000, (err) => {
+      if (err) return reply.send(err)
+      return reply
+        .etag('123456')
+        .send({ hello: 'world' })
+    })
+  })
+
+  instance.get('/two', (req, reply) => {
+    instance.cache.get('one', (err, obj) => {
+      t.notOk(err)
+      t.notOk(obj)
+    })
+  })
+
+  instance.listen(0, (err) => {
+    if (err) t.threw(err)
+    instance.server.unref()
+    const portNum = instance.server.address().port
+    const address = `http://127.0.0.1:${portNum}/one`
+
+    http
+      .get(address, (res) => {
+        const opts = {
+          host: '127.0.0.1',
+          port: portNum,
+          path: '/two',
+          headers: {
+            'if-none-match': '123456'
+          }
+        }
+        http.get(opts, (res) => {
+          t.equal(res.statusCode, 500)
+        }).on('error', t.threw)
+      })
+      .on('error', t.threw)
+  })
+})
+
 test('etags get stored in cache', (t) => {
   t.plan(1)
   const instance = fastify()

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -65,6 +65,54 @@ test('cache is usable', (t) => {
   })
 })
 
+test('cache is usable with function as plugin default options input', (t) => {
+  t.plan(3)
+  const instance = fastify()
+  instance
+    .register((i, o, n) => {
+      i.addHook('onRequest', function (req, reply, done) {
+        t.notOk(i[Symbol.for('fastify-caching.registered')])
+        done()
+      })
+      n()
+    })
+    .register(plugin, () => () => { })
+
+  instance.addHook('preParsing', function (req, reply, payload, done) {
+    t.equal(this[Symbol.for('fastify-caching.registered')], true)
+    done(null, payload)
+  })
+
+  instance.get('/one', (req, reply) => {
+    instance.cache.set('one', { one: true }, 100, (err) => {
+      if (err) return reply.send(err)
+      reply.redirect('/two')
+    })
+  })
+
+  instance.get('/two', (req, reply) => {
+    instance.cache.get('one', (err, obj) => {
+      if (err) t.threw(err)
+      t.same(obj.item, { one: true })
+      reply.send()
+    })
+  })
+
+  instance.listen(0, (err) => {
+    if (err) t.threw(err)
+    instance.server.unref()
+    const portNum = instance.server.address().port
+    const address = `http://127.0.0.1:${portNum}/one`
+    http
+      .get(address, (res) => {
+        if (res.statusCode > 300 && res.statusCode < 400 && res.headers.location) {
+          http.get(`http://127.0.0.1:${portNum}${res.headers.location}`, (res) => { }).on('error', t.threw)
+        }
+      })
+      .on('error', t.threw)
+  })
+})
+
 test('getting cache item with error returns error', (t) => {
   t.plan(1)
   const mockCache = {

--- a/test/headers.test.js
+++ b/test/headers.test.js
@@ -171,3 +171,25 @@ test('sets the expires header to a falsy value', (t) => {
     }).on('error', (err) => t.threw(err))
   })
 })
+
+test('sets the expires header to a custom value', (t) => {
+  t.plan(2)
+  const instance = fastify()
+  instance.register(plugin, { privacy: plugin.privacy.NOCACHE })
+  instance.get('/', (req, reply) => {
+    reply
+      .expires('foobar')
+      .send({ hello: 'world' })
+  })
+  instance.listen(0, (err) => {
+    if (err) t.threw(err)
+    instance.server.unref()
+    const portNum = instance.server.address().port
+    const address = `http://127.0.0.1:${portNum}`
+
+    http.get(address, (res) => {
+      t.ok(res.headers.expires)
+      t.equal(res.headers.expires, 'foobar')
+    }).on('error', (err) => t.threw(err))
+  })
+})

--- a/test/headers.test.js
+++ b/test/headers.test.js
@@ -44,6 +44,26 @@ test('decorators add headers', (t) => {
   })
 })
 
+test('sets etag header for falsy argument', (t) => {
+  t.plan(1)
+  const instance = fastify()
+  instance.register(plugin)
+  instance.get('/', (req, reply) => {
+    reply
+      .etag()
+      .send()
+  })
+  instance.listen(0, (err) => {
+    if (err) t.threw(err)
+    instance.server.unref()
+    const portNum = instance.server.address().port
+    const address = `http://127.0.0.1:${portNum}`
+    http.get(address, (res) => {
+      t.ok(res.headers.etag)
+    }).on('error', (err) => t.threw(err))
+  })
+})
+
 test('sets no-cache header', (t) => {
   t.plan(2)
   const instance = fastify()
@@ -127,6 +147,27 @@ test('sets the expires header', (t) => {
     http.get(address, (res) => {
       t.ok(res.headers.expires)
       t.equal(res.headers.expires, now.toUTCString())
+    }).on('error', (err) => t.threw(err))
+  })
+})
+
+test('sets the expires header to a falsy value', (t) => {
+  t.plan(1)
+  const instance = fastify()
+  instance.register(plugin, { privacy: plugin.privacy.NOCACHE })
+  instance.get('/', (req, reply) => {
+    reply
+      .expires()
+      .send({ hello: 'world' })
+  })
+  instance.listen(0, (err) => {
+    if (err) t.threw(err)
+    instance.server.unref()
+    const portNum = instance.server.address().port
+    const address = `http://127.0.0.1:${portNum}`
+
+    http.get(address, (res) => {
+      t.notOk(res.headers.expires)
     }).on('error', (err) => t.threw(err))
   })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


```
-----------|---------|----------|---------|---------|-------------------
File       | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-----------|---------|----------|---------|---------|-------------------
All files  |      98 |    93.33 |     100 |   97.78 |
 plugin.js |      98 |    93.33 |     100 |   97.78 | 58
-----------|---------|----------|---------|---------|-------------------
```

The [only uncovered line 58](https://github.com/fastify/fastify-caching/blob/a7082639e5652742bee7d6a8526978a51ec82551/plugin.js#L58) does not seem to be reachable. If this is a function, it will be evaluated at the time the plugin is registered while giving access to the Fastify instance. The plugin receives the return value instead of the original function. I might be missing something though :)


https://www.fastify.io/docs/latest/Plugins/#plugin-options