### PR TITLE
Added the ability to have s-maxage cache control headers (alongside existing max-age cache control headers)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -106,7 +106,7 @@ fastify.listen(3000, (err) => {
 for a *cache-response-directive* as defined by RFC 2616.
 + `expiresIn` (Default: `undefined`): a value, in seconds, for the *max-age* the
 resource may be cached. When this is set, and `privacy` is not set to `no-cache`,
-then `', max-age=<value>'` will be appended to the `cache-control` header. (300 seconds = 5 minutes)
+then `', max-age=<value>'` will be appended to the `cache-control` header. 
 + `cache` (Default: `abstract-cache.memclient`): an [abstract-cache][acache]
 protocol compliant cache object. Note: the plugin requires a cache instance to
 properly support the ETag mechanism. Therefore, if a falsy value is supplied

--- a/Readme.md
+++ b/Readme.md
@@ -97,7 +97,6 @@ fastify.listen(3000, (err) => {
 {
   privacy: 'value',
   expiresIn: 300,
-  serverExpiresIn: 2592000,
   cache: {get, set},
   cacheSegment: 'segment-name'
 }
@@ -108,13 +107,13 @@ for a *cache-response-directive* as defined by RFC 2616.
 + `expiresIn` (Default: `undefined`): a value, in seconds, for the *max-age* the
 resource may be cached. When this is set, and `privacy` is not set to `no-cache`,
 then `', max-age=<value>'` will be appended to the `cache-control` header. (300 seconds = 5 minutes)
-+ `serverExpiresIn` (Default: `undefined`): a value, in seconds, for the *max-age* the resource may be cached on the server. When this is set, and `privacy` is set to `public`,  then `', s-maxage=<value>'` will be appended to the `cache-control` header. (2,592,000 seconds = 30 days)
 + `cache` (Default: `abstract-cache.memclient`): an [abstract-cache][acache]
 protocol compliant cache object. Note: the plugin requires a cache instance to
 properly support the ETag mechanism. Therefore, if a falsy value is supplied
 the default will be used.
 + `cacheSegment` (Default: `'fastify-caching'`): segment identifier to use when
 communicating with the cache.
++ `serverExpiresIn` (Default: `undefined`): a value, in seconds, for the length of time the resource is fresh and may be held in a shared cache (e.g. a CDN). Shared caches will ignore max-age when this is specified, though browsers will continue to use max-age. Should be used with expiresIn, not in place of it. When this is set, and `privacy` is set to `public`,  then `', s-maxage=<value>'` will be appended to the `cache-control` header.  
 
 [acache]: https://www.npmjs.com/package/abstract-cache
 

--- a/Readme.md
+++ b/Readme.md
@@ -97,6 +97,7 @@ fastify.listen(3000, (err) => {
 {
   privacy: 'value',
   expiresIn: 300,
+  serverExpiresIn: 2592000,
   cache: {get, set},
   cacheSegment: 'segment-name'
 }
@@ -106,7 +107,8 @@ fastify.listen(3000, (err) => {
 for a *cache-response-directive* as defined by RFC 2616.
 + `expiresIn` (Default: `undefined`): a value, in seconds, for the *max-age* the
 resource may be cached. When this is set, and `privacy` is not set to `no-cache`,
-then `', max-age=<value>'` will be appended to the `cache-control` header.
+then `', max-age=<value>'` will be appended to the `cache-control` header. (300 seconds = 5 minutes)
++ `serverExpiresIn` (Default: `undefined`): a value, in seconds, for the *max-age* the resource may be cached on the server. When this is set, and `privacy` is set to `public`,  then `', s-maxage=<value>'` will be appended to the `cache-control` header. (2,592,000 seconds = 30 days)
 + `cache` (Default: `abstract-cache.memclient`): an [abstract-cache][acache]
 protocol compliant cache object. Note: the plugin requires a cache instance to
 properly support the ETag mechanism. Therefore, if a falsy value is supplied

--- a/plugin.js
+++ b/plugin.js
@@ -8,6 +8,7 @@ const abstractCache = require('abstract-cache')
 
 const defaultOptions = {
   expiresIn: undefined,
+  serverExpiresIn: undefined,
   privacy: undefined,
   cache: undefined,
   cacheSegment: 'fastify-caching'
@@ -67,6 +68,10 @@ function fastifyCachingPlugin (instance, options, next) {
     let value = _options.privacy
     if (_options.privacy.toLowerCase() !== 'no-cache' && _options.expiresIn) {
       value = `${_options.privacy}, max-age=${_options.expiresIn}`
+    }
+
+    if (_options.privacy.toLowerCase() === 'public' && _options.serverExpiresIn) {
+      value += `, s-maxage=${_options.serverExpiresIn}`
     }
 
     instance.addHook('onRequest', (req, res, next) => {

--- a/plugin.js
+++ b/plugin.js
@@ -70,7 +70,7 @@ function fastifyCachingPlugin (instance, options, next) {
       value = `${_options.privacy}, max-age=${_options.expiresIn}`
     }
 
-    if (_options.privacy.toLowerCase() === 'public' && _options.serverExpiresIn) {
+    if (_options.privacy !== undefined && _options.privacy.toLowerCase() === 'public' && _options.serverExpiresIn) {
       value += `, s-maxage=${_options.serverExpiresIn}`
     }
 


### PR DESCRIPTION
Added the ability to have s-maxage cache control headers when caching is public, so the length of time something is stored in a CDN can be longer than the length of time it is stored in a browser. e.g. For things stored in AWS CloudFront,  https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html#ExpirationDownloadDist

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ X ] run `npm run test` and `npm run benchmark`
- [ X ] tests and/or benchmarks are included
- [ X ] documentation is changed or added
- [ X ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
