### PR TITLE
test: prepare plugin for fastify 4.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10, 12, 14, 16]
+        node-version: [10, 12, 14, 16, 17]
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
   },
   "homepage": "https://github.com/fastify/fastify-caching#readme",
   "devDependencies": {
-    "fastify": "^3.0.0",
+    "fastify": "^3.24.1",
     "pre-commit": "^1.2.2",
     "snazzy": "^9.0.0",
-    "standard": "^16.0.1",
-    "tap": "^15.0.2"
+    "standard": "^16.0.4",
+    "tap": "^15.1.5"
   },
   "dependencies": {
     "abstract-cache": "^1.0.1",

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -210,7 +210,7 @@ test('etag cache life is customizable', (t) => {
       t.error(err)
 
       // We wait 70 milliseconds that the cache expires
-      setTimeout(async () => {
+      setTimeout(() => {
         fastify.inject({
           method: 'GET',
           path: '/one',

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -9,7 +9,6 @@ test('cache property gets added to instance', async (t) => {
   t.plan(2)
 
   const fastify = Fastify()
-
   await fastify.register(plugin)
   await fastify.ready()
 
@@ -21,16 +20,12 @@ test('cache is usable', async (t) => {
   t.plan(3)
 
   const fastify = Fastify()
-
-  await fastify
-    .register(async (instance, options) => {
-      instance.addHook('onRequest', async function (req, reply) {
-        t.notOk(instance[Symbol.for('fastify-caching.registered')])
-      })
+  await fastify.register(async (instance, options) => {
+    instance.addHook('onRequest', async function (req, reply) {
+      t.notOk(instance[Symbol.for('fastify-caching.registered')])
     })
-    .register(plugin)
-
-  t.teardown(fastify.close.bind(fastify))
+  })
+  await fastify.register(plugin)
 
   fastify.addHook('onRequest', async function (req, reply) {
     t.equal(this[Symbol.for('fastify-caching.registered')], true)
@@ -74,15 +69,12 @@ test('cache is usable with function as plugin default options input', async (t) 
   t.plan(3)
 
   const fastify = Fastify()
-  await fastify
-    .register(async (instance, options) => {
-      instance.addHook('onRequest', async function (req, reply) {
-        t.notOk(instance[Symbol.for('fastify-caching.registered')])
-      })
+  await fastify.register(async (instance, options) => {
+    instance.addHook('onRequest', async function (req, reply) {
+      t.notOk(instance[Symbol.for('fastify-caching.registered')])
     })
-    .register(plugin, () => () => { })
-
-  t.teardown(fastify.close.bind(fastify))
+  })
+  await fastify.register(plugin, () => () => { })
 
   fastify.addHook('onRequest', async function (req, reply) {
     t.equal(this[Symbol.for('fastify-caching.registered')], true)
@@ -133,8 +125,6 @@ test('getting cache item with error returns error', async (t) => {
   const fastify = Fastify()
   await fastify.register(plugin, { cache: mockCache })
 
-  t.teardown(fastify.close.bind(fastify))
-
   fastify.get('/one', (req, reply) => {
     fastify.cache.set('one', { one: true }, 1000, (err) => {
       if (err) return reply.send(err)
@@ -174,8 +164,6 @@ test('etags get stored in cache', async (t) => {
   const fastify = Fastify()
   await fastify.register(plugin)
 
-  t.teardown(fastify.close.bind(fastify))
-
   fastify.get('/one', (req, reply) => {
     reply
       .etag('123456')
@@ -204,8 +192,6 @@ test('etag cache life is customizable', (t) => {
 
   const fastify = Fastify()
   fastify.register(plugin)
-
-  t.teardown(fastify.close.bind(fastify))
 
   fastify.get('/one', function (req, reply) {
     reply
@@ -245,8 +231,6 @@ test('returns response payload', async (t) => {
 
   const fastify = Fastify()
   await fastify.register(plugin)
-
-  t.teardown(fastify.close.bind(fastify))
 
   fastify.get('/one', (req, reply) => {
     reply

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -24,18 +24,16 @@ test('cache is usable', async (t) => {
 
   await fastify
     .register(async (instance, options) => {
-      instance.addHook('onRequest', function (req, reply, done) {
+      instance.addHook('onRequest', async function (req, reply) {
         t.notOk(instance[Symbol.for('fastify-caching.registered')])
-        done()
       })
     })
     .register(plugin)
 
   t.teardown(fastify.close.bind(fastify))
 
-  fastify.addHook('onRequest', function (req, reply, done) {
+  fastify.addHook('onRequest', async function (req, reply) {
     t.equal(this[Symbol.for('fastify-caching.registered')], true)
-    done()
   })
 
   fastify.get('/one', (req, reply) => {
@@ -78,18 +76,16 @@ test('cache is usable with function as plugin default options input', async (t) 
   const fastify = Fastify()
   await fastify
     .register(async (instance, options) => {
-      instance.addHook('onRequest', function (req, reply, done) {
+      instance.addHook('onRequest', async function (req, reply) {
         t.notOk(instance[Symbol.for('fastify-caching.registered')])
-        done()
       })
     })
     .register(plugin, () => () => { })
 
   t.teardown(fastify.close.bind(fastify))
 
-  fastify.addHook('onRequest', function (req, reply, done) {
+  fastify.addHook('onRequest', async function (req, reply) {
     t.equal(this[Symbol.for('fastify-caching.registered')], true)
-    done()
   })
 
   fastify.get('/one', (req, reply) => {
@@ -269,5 +265,6 @@ test('returns response payload', async (t) => {
     method: 'GET',
     path: '/one'
   })
+
   t.same(JSON.parse(response.payload), { hello: 'world' })
 })

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -1,130 +1,146 @@
 'use strict'
 
-const http = require('http')
-const test = require('tap').test
+const { test } = require('tap')
 const plugin = require('../plugin')
 
-const fastify = require('fastify')
+const Fastify = require('fastify')
 
-test('cache property gets added to instance', (t) => {
+test('cache property gets added to instance', async (t) => {
   t.plan(2)
-  const instance = fastify()
-  instance
-    .register(plugin)
-    .ready(() => {
-      t.ok(instance.cache)
-      t.ok(instance.cache.set)
-    })
+
+  const fastify = Fastify()
+
+  await fastify.register(plugin)
+  await fastify.ready()
+
+  t.ok(fastify.cache)
+  t.ok(fastify.cache.set)
 })
 
-test('cache is usable', (t) => {
+test('cache is usable', async (t) => {
   t.plan(3)
-  const instance = fastify()
-  instance
-    .register((i, o, n) => {
-      i.addHook('onRequest', function (req, reply, done) {
-        t.notOk(i[Symbol.for('fastify-caching.registered')])
+
+  const fastify = Fastify()
+
+  await fastify
+    .register(async (instance, options) => {
+      instance.addHook('onRequest', function (req, reply, done) {
+        t.notOk(instance[Symbol.for('fastify-caching.registered')])
         done()
       })
-      n()
     })
     .register(plugin)
 
-  instance.addHook('onRequest', function (req, reply, done) {
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.addHook('onRequest', function (req, reply, done) {
     t.equal(this[Symbol.for('fastify-caching.registered')], true)
     done()
   })
 
-  instance.get('/one', (req, reply) => {
-    instance.cache.set('one', { one: true }, 100, (err) => {
+  fastify.get('/one', (req, reply) => {
+    fastify.cache.set('one', { one: true }, 100, (err) => {
       if (err) return reply.send(err)
       reply.redirect('/two')
     })
   })
 
-  instance.get('/two', (req, reply) => {
-    instance.cache.get('one', (err, obj) => {
+  fastify.get('/two', (req, reply) => {
+    fastify.cache.get('one', (err, obj) => {
       if (err) t.threw(err)
       t.same(obj.item, { one: true })
       reply.send()
     })
   })
 
-  instance.listen(0, (err) => {
-    if (err) t.threw(err)
-    instance.server.unref()
-    const portNum = instance.server.address().port
-    const address = `http://127.0.0.1:${portNum}/one`
-    http
-      .get(address, (res) => {
-        if (res.statusCode > 300 && res.statusCode < 400 && res.headers.location) {
-          http.get(`http://127.0.0.1:${portNum}${res.headers.location}`, (res) => {}).on('error', t.threw)
-        }
-      })
-      .on('error', t.threw)
+  await fastify.ready()
+
+  const response = await fastify.inject({
+    method: 'GET',
+    path: '/one'
   })
+
+  if (
+    response.statusCode > 300 &&
+    response.statusCode < 400 &&
+    response.headers.location
+  ) {
+    await fastify.inject({
+      method: 'GET',
+      path: response.headers.location
+    })
+  }
 })
 
-test('cache is usable with function as plugin default options input', (t) => {
+test('cache is usable with function as plugin default options input', async (t) => {
   t.plan(3)
-  const instance = fastify()
-  instance
-    .register((i, o, n) => {
-      i.addHook('onRequest', function (req, reply, done) {
-        t.notOk(i[Symbol.for('fastify-caching.registered')])
+
+  const fastify = Fastify()
+  await fastify
+    .register(async (instance, options) => {
+      instance.addHook('onRequest', function (req, reply, done) {
+        t.notOk(instance[Symbol.for('fastify-caching.registered')])
         done()
       })
-      n()
     })
     .register(plugin, () => () => { })
 
-  instance.addHook('onRequest', function (req, reply, done) {
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.addHook('onRequest', function (req, reply, done) {
     t.equal(this[Symbol.for('fastify-caching.registered')], true)
     done()
   })
 
-  instance.get('/one', (req, reply) => {
-    instance.cache.set('one', { one: true }, 100, (err) => {
+  fastify.get('/one', (req, reply) => {
+    fastify.cache.set('one', { one: true }, 100, (err) => {
       if (err) return reply.send(err)
       reply.redirect('/two')
     })
   })
 
-  instance.get('/two', (req, reply) => {
-    instance.cache.get('one', (err, obj) => {
+  fastify.get('/two', (req, reply) => {
+    fastify.cache.get('one', (err, obj) => {
       if (err) t.threw(err)
       t.same(obj.item, { one: true })
       reply.send()
     })
   })
 
-  instance.listen(0, (err) => {
-    if (err) t.threw(err)
-    instance.server.unref()
-    const portNum = instance.server.address().port
-    const address = `http://127.0.0.1:${portNum}/one`
-    http
-      .get(address, (res) => {
-        if (res.statusCode > 300 && res.statusCode < 400 && res.headers.location) {
-          http.get(`http://127.0.0.1:${portNum}${res.headers.location}`, (res) => { }).on('error', t.threw)
-        }
-      })
-      .on('error', t.threw)
+  await fastify.ready()
+
+  const response = await fastify.inject({
+    method: 'GET',
+    path: '/one'
   })
+
+  if (
+    response.statusCode > 300 &&
+    response.statusCode < 400 &&
+    response.headers.location
+  ) {
+    await fastify.inject({
+      method: 'GET',
+      path: response.headers.location
+    })
+  }
 })
 
-test('getting cache item with error returns error', (t) => {
+test('getting cache item with error returns error', async (t) => {
   t.plan(1)
+
   const mockCache = {
     get: (info, callback) => callback(new Error('cache.get always errors')),
     set: (key, value, ttl, callback) => callback()
   }
 
-  const instance = fastify()
-  instance.register(plugin, { cache: mockCache })
+  const fastify = Fastify()
+  await fastify.register(plugin, { cache: mockCache })
 
-  instance.get('/one', (req, reply) => {
-    instance.cache.set('one', { one: true }, 1000, (err) => {
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.get('/one', (req, reply) => {
+    fastify.cache.set('one', { one: true }, 1000, (err) => {
       if (err) return reply.send(err)
       return reply
         .etag('123456')
@@ -132,140 +148,126 @@ test('getting cache item with error returns error', (t) => {
     })
   })
 
-  instance.get('/two', (req, reply) => {
-    instance.cache.get('one', (err, obj) => {
+  fastify.get('/two', (req, reply) => {
+    fastify.cache.get('one', (err, obj) => {
       t.notOk(err)
       t.notOk(obj)
     })
   })
 
-  instance.listen(0, (err) => {
-    if (err) t.threw(err)
-    instance.server.unref()
-    const portNum = instance.server.address().port
-    const address = `http://127.0.0.1:${portNum}/one`
+  await fastify.ready()
 
-    http
-      .get(address, (res) => {
-        const opts = {
-          host: '127.0.0.1',
-          port: portNum,
-          path: '/two',
-          headers: {
-            'if-none-match': '123456'
-          }
-        }
-        http.get(opts, (res) => {
-          t.equal(res.statusCode, 500)
-        }).on('error', t.threw)
-      })
-      .on('error', t.threw)
+  await fastify.inject({
+    method: 'GET',
+    path: '/one'
   })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    path: '/two',
+    headers: {
+      'if-none-match': '123456'
+    }
+  })
+  t.equal(response.statusCode, 500)
 })
 
-test('etags get stored in cache', (t) => {
+test('etags get stored in cache', async (t) => {
   t.plan(1)
-  const instance = fastify()
-  instance.register(plugin)
 
-  instance.get('/one', (req, reply) => {
+  const fastify = Fastify()
+  await fastify.register(plugin)
+
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.get('/one', (req, reply) => {
     reply
       .etag('123456')
       .send({ hello: 'world' })
   })
 
-  instance.listen(0, (err) => {
-    if (err) t.threw(err)
-    instance.server.unref()
-    const portNum = instance.server.address().port
-    const address = `http://127.0.0.1:${portNum}/one`
-    http
-      .get(address, (res) => {
-        const opts = {
-          host: '127.0.0.1',
-          port: portNum,
-          path: '/one',
-          headers: {
-            'if-none-match': '123456'
-          }
-        }
-        http
-          .get(opts, (res) => {
-            t.equal(res.statusCode, 304)
-          })
-          .on('error', t.threw)
-      })
-      .on('error', t.threw)
+  await fastify.ready()
+
+  await fastify.inject({
+    method: 'GET',
+    path: '/one'
   })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    path: '/one',
+    headers: {
+      'if-none-match': '123456'
+    }
+  })
+  t.equal(response.statusCode, 304)
 })
 
 test('etag cache life is customizable', (t) => {
-  t.plan(1)
-  const instance = fastify()
-  instance.register(plugin)
+  t.plan(4)
 
-  instance.get('/one', function (req, reply) {
+  const fastify = Fastify()
+  fastify.register(plugin)
+
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.get('/one', function (req, reply) {
     reply
+      // We set a cache lifetime of 50 milliseconds
       .etag('123456', 50)
       .send({ hello: 'world' })
   })
 
-  instance.listen(0, (err) => {
-    if (err) t.threw(err)
-    instance.server.unref()
-    const portNum = instance.server.address().port
-    const address = `http://127.0.0.1:${portNum}/one`
-    http
-      .get(address, (res) => {
-        const opts = {
-          host: '127.0.0.1',
-          port: portNum,
+  fastify.ready((err) => {
+    t.error(err)
+
+    fastify.inject({
+      method: 'GET',
+      path: '/one'
+    }, (err, _response) => {
+      t.error(err)
+
+      // We wait 70 milliseconds that the cache expires
+      setTimeout(async () => {
+        fastify.inject({
+          method: 'GET',
           path: '/one',
           headers: {
             'if-none-match': '123456'
           }
-        }
-        setTimeout(() => {
-          http
-            .get(opts, (res) => {
-              t.equal(res.statusCode, 200)
-            })
-            .on('error', t.threw)
-        }, 150)
-      })
-      .on('error', t.threw)
+        }, (err, response) => {
+          t.error(err)
+          t.equal(response.statusCode, 200)
+        })
+      }, 70)
+    })
   })
 })
 
-test('returns response payload', (t) => {
+test('returns response payload', async (t) => {
   t.plan(1)
-  const instance = fastify()
-  instance.register(plugin)
 
-  instance.get('/one', (req, reply) => {
+  const fastify = Fastify()
+  await fastify.register(plugin)
+
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.get('/one', (req, reply) => {
     reply
       .etag('123456', 300)
       .send({ hello: 'world' })
   })
 
-  instance.listen(0, (err) => {
-    if (err) t.threw(err)
-    instance.server.unref()
-    const portNum = instance.server.address().port
-    const opts = {
-      host: '127.0.0.1',
-      port: portNum,
-      path: '/one'
-    }
-    http
-      .get(opts, (res) => {
-        let payload = ''
-        res.on('data', (chunk) => {
-          payload += chunk
-        }).on('end', () => {
-          t.same(JSON.parse(payload), { hello: 'world' })
-        }).on('error', t.threw)
-      })
-      .on('error', t.threw)
+  await fastify.ready()
+
+  await fastify.inject({
+    method: 'GET',
+    path: '/one'
   })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    path: '/one'
+  })
+  t.same(JSON.parse(response.payload), { hello: 'world' })
 })

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -30,9 +30,9 @@ test('cache is usable', (t) => {
     })
     .register(plugin)
 
-  instance.addHook('preParsing', function (req, reply, payload, done) {
+  instance.addHook('onRequest', function (req, reply, done) {
     t.equal(this[Symbol.for('fastify-caching.registered')], true)
-    done(null, payload)
+    done()
   })
 
   instance.get('/one', (req, reply) => {
@@ -78,9 +78,9 @@ test('cache is usable with function as plugin default options input', (t) => {
     })
     .register(plugin, () => () => { })
 
-  instance.addHook('preParsing', function (req, reply, payload, done) {
+  instance.addHook('onRequest', function (req, reply, done) {
     t.equal(this[Symbol.for('fastify-caching.registered')], true)
-    done(null, payload)
+    done()
   })
 
   instance.get('/one', (req, reply) => {

--- a/test/headers.test.js
+++ b/test/headers.test.js
@@ -10,8 +10,6 @@ test('decorators get added', async (t) => {
   const fastify = Fastify()
   await fastify.register(plugin)
 
-  t.teardown(fastify.close.bind(fastify))
-
   fastify.get('/', (req, reply) => {
     t.ok(reply.etag)
     reply.send()
@@ -32,8 +30,6 @@ test('decorators add headers', async (t) => {
 
   const fastify = Fastify()
   await fastify.register(plugin)
-
-  t.teardown(fastify.close.bind(fastify))
 
   fastify.get('/', (req, reply) => {
     reply
@@ -57,8 +53,6 @@ test('sets etag header for falsy argument', async (t) => {
   const fastify = Fastify()
   await fastify.register(plugin)
 
-  t.teardown(fastify.close.bind(fastify))
-
   fastify.get('/', (req, reply) => {
     reply
       .etag()
@@ -79,8 +73,6 @@ test('sets no-cache header', async (t) => {
 
   const fastify = Fastify()
   await fastify.register(plugin, { privacy: plugin.privacy.NOCACHE })
-
-  t.teardown(fastify.close.bind(fastify))
 
   fastify.get('/', (req, reply) => {
     reply.send({ hello: 'world' })
@@ -106,8 +98,6 @@ test('sets private with max-age header', async (t) => {
 
   const fastify = Fastify()
   await fastify.register(plugin, opts)
-
-  t.teardown(fastify.close.bind(fastify))
 
   fastify.get('/', (req, reply) => {
     reply.send({ hello: 'world' })
@@ -135,8 +125,6 @@ test('sets public with max-age and s-maxage header', async (t) => {
   const fastify = Fastify()
   await fastify.register(plugin, opts)
 
-  t.teardown(fastify.close.bind(fastify))
-
   fastify.get('/', (req, reply) => {
     reply.send({ hello: 'world' })
   })
@@ -163,8 +151,6 @@ test('only sets max-age and ignores s-maxage with private header', async (t) => 
   const fastify = Fastify()
   await fastify.register(plugin, opts)
 
-  t.teardown(fastify.close.bind(fastify))
-
   fastify.get('/', (req, reply) => {
     reply.send({ hello: 'world' })
   })
@@ -190,8 +176,6 @@ test('s-maxage is optional with public header', async (t) => {
   const fastify = Fastify()
   await fastify.register(plugin, opts)
 
-  t.teardown(fastify.close.bind(fastify))
-
   fastify.get('/', (req, reply) => {
     reply.send({ hello: 'world' })
   })
@@ -211,8 +195,6 @@ test('sets no-store with max-age header', async (t) => {
 
   const fastify = Fastify()
   await fastify.register(plugin, { privacy: 'no-store', expiresIn: 300 })
-
-  t.teardown(fastify.close.bind(fastify))
 
   fastify.get('/', (req, reply) => {
     reply.send({ hello: 'world' })
@@ -236,8 +218,6 @@ test('sets the expires header', async (t) => {
   const fastify = Fastify()
   await fastify.register(plugin, { privacy: plugin.privacy.NOCACHE })
 
-  t.teardown(fastify.close.bind(fastify))
-
   fastify.get('/', (req, reply) => {
     reply
       .expires(now)
@@ -260,8 +240,6 @@ test('sets the expires header to a falsy value', async (t) => {
   const fastify = Fastify()
   await fastify.register(plugin, { privacy: plugin.privacy.NOCACHE })
 
-  t.teardown(fastify.close.bind(fastify))
-
   fastify.get('/', (req, reply) => {
     reply
       .expires()
@@ -282,8 +260,6 @@ test('sets the expires header to a custom value', async (t) => {
 
   const fastify = Fastify()
   await fastify.register(plugin, { privacy: plugin.privacy.NOCACHE })
-
-  t.teardown(fastify.close.bind(fastify))
 
   fastify.get('/', (req, reply) => {
     reply

--- a/test/headers.test.js
+++ b/test/headers.test.js
@@ -1,269 +1,302 @@
 'use strict'
 
-const http = require('http')
-const test = require('tap').test
+const { test } = require('tap')
+const Fastify = require('fastify')
 const plugin = require('../plugin')
-const fastify = require('fastify')
 
-test('decorators get added', (t) => {
+test('decorators get added', async (t) => {
   t.plan(1)
-  const instance = fastify()
-  instance.register(plugin)
-  instance.get('/', (req, reply) => {
+
+  const fastify = Fastify()
+  await fastify.register(plugin)
+
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.get('/', (req, reply) => {
     t.ok(reply.etag)
     reply.send()
   })
-  instance.listen(0, (err) => {
-    if (err) t.threw(err)
-    instance.server.unref()
-    const portNum = instance.server.address().port
-    const address = `http://127.0.0.1:${portNum}`
-    http.get(address, (res) => {}).on('error', (err) => t.threw(err))
+
+  await fastify.ready()
+
+  await fastify.inject({
+    method: 'GET',
+    path: '/'
   })
 })
 
-test('decorators add headers', (t) => {
+test('decorators add headers', async (t) => {
   t.plan(2)
+
   const tag = '123456'
-  const instance = fastify()
-  instance.register(plugin)
-  instance.get('/', (req, reply) => {
+
+  const fastify = Fastify()
+  await fastify.register(plugin)
+
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.get('/', (req, reply) => {
     reply
       .etag(tag)
       .send()
   })
-  instance.listen(0, (err) => {
-    if (err) t.threw(err)
-    instance.server.unref()
-    const portNum = instance.server.address().port
-    const address = `http://127.0.0.1:${portNum}`
-    http.get(address, (res) => {
-      t.ok(res.headers.etag)
-      t.equal(res.headers.etag, tag)
-    }).on('error', (err) => t.threw(err))
+
+  await fastify.ready()
+
+  const response = await fastify.inject({
+    method: 'GET',
+    path: '/'
   })
+  t.ok(response.headers.etag)
+  t.equal(response.headers.etag, tag)
 })
 
-test('sets etag header for falsy argument', (t) => {
+test('sets etag header for falsy argument', async (t) => {
   t.plan(1)
-  const instance = fastify()
-  instance.register(plugin)
-  instance.get('/', (req, reply) => {
+
+  const fastify = Fastify()
+  await fastify.register(plugin)
+
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.get('/', (req, reply) => {
     reply
       .etag()
       .send()
   })
-  instance.listen(0, (err) => {
-    if (err) t.threw(err)
-    instance.server.unref()
-    const portNum = instance.server.address().port
-    const address = `http://127.0.0.1:${portNum}`
-    http.get(address, (res) => {
-      t.ok(res.headers.etag)
-    }).on('error', (err) => t.threw(err))
+
+  await fastify.ready()
+
+  const response = await fastify.inject({
+    method: 'GET',
+    path: '/'
   })
+  t.ok(response.headers.etag)
 })
 
-test('sets no-cache header', (t) => {
+test('sets no-cache header', async (t) => {
   t.plan(2)
-  const instance = fastify()
-  instance.register(plugin, { privacy: plugin.privacy.NOCACHE })
-  instance.get('/', (req, reply) => {
+
+  const fastify = Fastify()
+  await fastify.register(plugin, { privacy: plugin.privacy.NOCACHE })
+
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.get('/', (req, reply) => {
     reply.send({ hello: 'world' })
   })
-  instance.listen(0, (err) => {
-    if (err) t.threw(err)
-    instance.server.unref()
-    const portNum = instance.server.address().port
-    const address = `http://127.0.0.1:${portNum}`
 
-    http.get(address, (res) => {
-      t.ok(res.headers['cache-control'])
-      t.equal(res.headers['cache-control'], 'no-cache')
-    }).on('error', (err) => t.threw(err))
+  await fastify.ready()
+
+  const response = await fastify.inject({
+    method: 'GET',
+    path: '/'
   })
+  t.ok(response.headers['cache-control'])
+  t.equal(response.headers['cache-control'], 'no-cache')
 })
 
-test('sets private with max-age header', (t) => {
+test('sets private with max-age header', async (t) => {
   t.plan(2)
-  const instance = fastify()
+
   const opts = {
     privacy: plugin.privacy.PRIVATE,
     expiresIn: 300
   }
-  instance.register(plugin, opts)
-  instance.get('/', (req, reply) => {
+
+  const fastify = Fastify()
+  await fastify.register(plugin, opts)
+
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.get('/', (req, reply) => {
     reply.send({ hello: 'world' })
   })
-  instance.listen(0, (err) => {
-    if (err) t.threw(err)
-    instance.server.unref()
-    const portNum = instance.server.address().port
-    const address = `http://127.0.0.1:${portNum}`
 
-    http.get(address, (res) => {
-      t.ok(res.headers['cache-control'])
-      t.equal(res.headers['cache-control'], 'private, max-age=300')
-    }).on('error', (err) => t.threw(err))
+  await fastify.ready()
+
+  const response = await fastify.inject({
+    method: 'GET',
+    path: '/'
   })
+  t.ok(response.headers['cache-control'])
+  t.equal(response.headers['cache-control'], 'private, max-age=300')
 })
 
-test('sets public with max-age and s-maxage header', (t) => {
+test('sets public with max-age and s-maxage header', async (t) => {
   t.plan(2)
-  const instance = fastify()
+
   const opts = {
     privacy: plugin.privacy.PUBLIC,
     expiresIn: 300,
     serverExpiresIn: 12345
   }
-  instance.register(plugin, opts)
-  instance.get('/', (req, reply) => {
+
+  const fastify = Fastify()
+  await fastify.register(plugin, opts)
+
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.get('/', (req, reply) => {
     reply.send({ hello: 'world' })
   })
-  instance.listen(0, (err) => {
-    if (err) t.threw(err)
-    instance.server.unref()
-    const portNum = instance.server.address().port
-    const address = `http://127.0.0.1:${portNum}`
 
-    http.get(address, (res) => {
-      t.ok(res.headers['cache-control'])
-      t.equal(res.headers['cache-control'], 'public, max-age=300, s-maxage=12345')
-    }).on('error', (err) => t.threw(err))
+  await fastify.ready()
+
+  const response = await fastify.inject({
+    method: 'GET',
+    path: '/'
   })
+  t.ok(response.headers['cache-control'])
+  t.equal(response.headers['cache-control'], 'public, max-age=300, s-maxage=12345')
 })
 
-test('only sets max-age and ignores s-maxage with private header', (t) => {
+test('only sets max-age and ignores s-maxage with private header', async (t) => {
   t.plan(2)
-  const instance = fastify()
+
   const opts = {
     privacy: plugin.privacy.PRIVATE,
     expiresIn: 300,
     serverExpiresIn: 12345
   }
-  instance.register(plugin, opts)
-  instance.get('/', (req, reply) => {
+
+  const fastify = Fastify()
+  await fastify.register(plugin, opts)
+
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.get('/', (req, reply) => {
     reply.send({ hello: 'world' })
   })
-  instance.listen(0, (err) => {
-    if (err) t.threw(err)
-    instance.server.unref()
-    const portNum = instance.server.address().port
-    const address = `http://127.0.0.1:${portNum}`
 
-    http.get(address, (res) => {
-      t.ok(res.headers['cache-control'])
-      t.equal(res.headers['cache-control'], 'private, max-age=300')
-    }).on('error', (err) => t.threw(err))
+  await fastify.ready()
+
+  const response = await fastify.inject({
+    method: 'GET',
+    path: '/'
   })
+  t.ok(response.headers['cache-control'])
+  t.equal(response.headers['cache-control'], 'private, max-age=300')
 })
 
-test('s-maxage is optional with public header', (t) => {
+test('s-maxage is optional with public header', async (t) => {
   t.plan(2)
-  const instance = fastify()
+
   const opts = {
     privacy: plugin.privacy.PUBLIC,
     expiresIn: 300
   }
-  instance.register(plugin, opts)
-  instance.get('/', (req, reply) => {
+
+  const fastify = Fastify()
+  await fastify.register(plugin, opts)
+
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.get('/', (req, reply) => {
     reply.send({ hello: 'world' })
   })
-  instance.listen(0, (err) => {
-    if (err) t.threw(err)
-    instance.server.unref()
-    const portNum = instance.server.address().port
-    const address = `http://127.0.0.1:${portNum}`
 
-    http.get(address, (res) => {
-      t.ok(res.headers['cache-control'])
-      t.equal(res.headers['cache-control'], 'public, max-age=300')
-    }).on('error', (err) => t.threw(err))
+  await fastify.ready()
+
+  const response = await fastify.inject({
+    method: 'GET',
+    path: '/'
   })
+  t.ok(response.headers['cache-control'])
+  t.equal(response.headers['cache-control'], 'public, max-age=300')
 })
 
-test('sets no-store with max-age header', (t) => {
+test('sets no-store with max-age header', async (t) => {
   t.plan(2)
-  const instance = fastify()
-  instance.register(plugin, { privacy: 'no-store', expiresIn: 300 })
-  instance.get('/', (req, reply) => {
+
+  const fastify = Fastify()
+  await fastify.register(plugin, { privacy: 'no-store', expiresIn: 300 })
+
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.get('/', (req, reply) => {
     reply.send({ hello: 'world' })
   })
-  instance.listen(0, (err) => {
-    if (err) t.threw(err)
-    instance.server.unref()
-    const portNum = instance.server.address().port
-    const address = `http://127.0.0.1:${portNum}`
 
-    http.get(address, (res) => {
-      t.ok(res.headers['cache-control'])
-      t.equal(res.headers['cache-control'], 'no-store, max-age=300')
-    }).on('error', (err) => t.threw(err))
+  await fastify.ready()
+
+  const response = await fastify.inject({
+    method: 'GET',
+    path: '/'
   })
+  t.ok(response.headers['cache-control'])
+  t.equal(response.headers['cache-control'], 'no-store, max-age=300')
 })
 
-test('sets the expires header', (t) => {
+test('sets the expires header', async (t) => {
   t.plan(2)
+
   const now = new Date()
-  const instance = fastify()
-  instance.register(plugin, { privacy: plugin.privacy.NOCACHE })
-  instance.get('/', (req, reply) => {
+
+  const fastify = Fastify()
+  await fastify.register(plugin, { privacy: plugin.privacy.NOCACHE })
+
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.get('/', (req, reply) => {
     reply
       .expires(now)
       .send({ hello: 'world' })
   })
-  instance.listen(0, (err) => {
-    if (err) t.threw(err)
-    instance.server.unref()
-    const portNum = instance.server.address().port
-    const address = `http://127.0.0.1:${portNum}`
 
-    http.get(address, (res) => {
-      t.ok(res.headers.expires)
-      t.equal(res.headers.expires, now.toUTCString())
-    }).on('error', (err) => t.threw(err))
+  await fastify.ready()
+
+  const response = await fastify.inject({
+    method: 'GET',
+    path: '/'
   })
+  t.ok(response.headers.expires)
+  t.equal(response.headers.expires, now.toUTCString())
 })
 
-test('sets the expires header to a falsy value', (t) => {
+test('sets the expires header to a falsy value', async (t) => {
   t.plan(1)
-  const instance = fastify()
-  instance.register(plugin, { privacy: plugin.privacy.NOCACHE })
-  instance.get('/', (req, reply) => {
+
+  const fastify = Fastify()
+  await fastify.register(plugin, { privacy: plugin.privacy.NOCACHE })
+
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.get('/', (req, reply) => {
     reply
       .expires()
       .send({ hello: 'world' })
   })
-  instance.listen(0, (err) => {
-    if (err) t.threw(err)
-    instance.server.unref()
-    const portNum = instance.server.address().port
-    const address = `http://127.0.0.1:${portNum}`
 
-    http.get(address, (res) => {
-      t.notOk(res.headers.expires)
-    }).on('error', (err) => t.threw(err))
+  await fastify.ready()
+
+  const response = await fastify.inject({
+    method: 'GET',
+    path: '/'
   })
+  t.notOk(response.headers.expires)
 })
 
-test('sets the expires header to a custom value', (t) => {
+test('sets the expires header to a custom value', async (t) => {
   t.plan(2)
-  const instance = fastify()
-  instance.register(plugin, { privacy: plugin.privacy.NOCACHE })
-  instance.get('/', (req, reply) => {
+
+  const fastify = Fastify()
+  await fastify.register(plugin, { privacy: plugin.privacy.NOCACHE })
+
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.get('/', (req, reply) => {
     reply
       .expires('foobar')
       .send({ hello: 'world' })
   })
-  instance.listen(0, (err) => {
-    if (err) t.threw(err)
-    instance.server.unref()
-    const portNum = instance.server.address().port
-    const address = `http://127.0.0.1:${portNum}`
 
-    http.get(address, (res) => {
-      t.ok(res.headers.expires)
-      t.equal(res.headers.expires, 'foobar')
-    }).on('error', (err) => t.threw(err))
+  await fastify.ready()
+
+  const response = await fastify.inject({
+    method: 'GET',
+    path: '/'
   })
+  t.ok(response.headers.expires)
+  t.equal(response.headers.expires, 'foobar')
 })


### PR DESCRIPTION
Hello.
This PR aims to :
- Replace `preParsing` hooks with `onRequest` hooks inside tests (https://github.com/fastify/fastify/issues/3503)
- Rewrite all tests (replacing Node.js `http.get` calls with `fastify.inject`, `async/await` ... )
- Add Node.js 17 to the CI matrix
- Fix windows flacky tests (maybe ... I hope at least :crossed_fingers: :smile_cat:)

#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests ~~and/or benchmarks~~ are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
