### PR TITLE
test: increase cache TTL

### DIFF
--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -17,7 +17,7 @@ test('cache property gets added to instance', async (t) => {
 })
 
 test('cache is usable', async (t) => {
-  t.plan(3)
+  t.plan(4)
 
   const fastify = Fastify()
   await fastify.register(async (instance, options) => {
@@ -32,7 +32,7 @@ test('cache is usable', async (t) => {
   })
 
   fastify.get('/one', (req, reply) => {
-    fastify.cache.set('one', { one: true }, 100, (err) => {
+    fastify.cache.set('one', { one: true }, 1000, (err) => {
       if (err) return reply.send(err)
       reply.redirect('/two')
     })
@@ -40,8 +40,9 @@ test('cache is usable', async (t) => {
 
   fastify.get('/two', (req, reply) => {
     fastify.cache.get('one', (err, obj) => {
-      if (err) t.threw(err)
+      t.error(err)
       t.same(obj.item, { one: true })
+
       reply.send()
     })
   })
@@ -66,7 +67,7 @@ test('cache is usable', async (t) => {
 })
 
 test('cache is usable with function as plugin default options input', async (t) => {
-  t.plan(3)
+  t.plan(4)
 
   const fastify = Fastify()
   await fastify.register(async (instance, options) => {
@@ -81,7 +82,7 @@ test('cache is usable with function as plugin default options input', async (t) 
   })
 
   fastify.get('/one', (req, reply) => {
-    fastify.cache.set('one', { one: true }, 100, (err) => {
+    fastify.cache.set('one', { one: true }, 1000, (err) => {
       if (err) return reply.send(err)
       reply.redirect('/two')
     })
@@ -89,8 +90,9 @@ test('cache is usable with function as plugin default options input', async (t) 
 
   fastify.get('/two', (req, reply) => {
     fastify.cache.get('one', (err, obj) => {
-      if (err) t.threw(err)
+      t.error(err)
       t.same(obj.item, { one: true })
+
       reply.send()
     })
   })


### PR DESCRIPTION
Hello.

Following https://github.com/fastify/fastify-caching/pull/84

This PR aims to :
- Fix windows flacky tests by increasing the cache TTL (for real this time... I hope at least :crossed_fingers: :smile_cat:)

#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests ~~and/or benchmarks~~ are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
