### PR TITLE
Don't override cache-control if it has already been set

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ function fastifyCaching (instance, options, next) {
     }
 
     instance.addHook('onRequest', (req, res, next) => {
-      if (!res.hasHeader('Cache-control')) {
+      if (res.hasHeader('Cache-control') === false) {
         res.header('Cache-control', value)
       }
       next()

--- a/index.js
+++ b/index.js
@@ -75,7 +75,9 @@ function fastifyCaching (instance, options, next) {
     }
 
     instance.addHook('onRequest', (req, res, next) => {
-      res.header('Cache-control', value)
+      if (!res.getHeader('Cache-control')) {
+        res.header('Cache-control', value)
+      }
       next()
     })
   }

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ function fastifyCaching (instance, options, next) {
     }
 
     instance.addHook('onRequest', (req, res, next) => {
-      if (!res.getHeader('Cache-control')) {
+      if (!res.hasHeader('Cache-control')) {
         res.header('Cache-control', value)
       }
       next()

--- a/test/headers.test.js
+++ b/test/headers.test.js
@@ -2,7 +2,6 @@
 
 const { test } = require('tap')
 const Fastify = require('fastify')
-const fp = require('fastify-plugin')
 const plugin = require('..')
 
 test('decorators get added', async (t) => {
@@ -150,11 +149,9 @@ test('do not set headers if another upstream plugin already sets it', async (t) 
   }
 
   const fastify = Fastify()
-  await fastify.register(fp(async (fastify, opts) => {
-    fastify.addHook('onRequest', async (req, reply) => {
-      reply.header('cache-control', 'do not override')
-    })
-  }))
+  fastify.addHook('onRequest', async (req, reply) => {
+    reply.header('cache-control', 'do not override')
+  })
   await fastify.register(plugin, opts)
 
   fastify.get('/', (req, reply) => {


### PR DESCRIPTION
Resolves https://github.com/fastify/fastify-caching/issues/14

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [?] documentation is changed or added -> not sure how to document this.
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
