### PR TITLE
fix: typings of fastify.cache.get

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -35,6 +35,12 @@ type FastifyCaching = FastifyPluginCallback<fastifyCaching.FastifyCachingPluginO
   privacy: fastifyCaching.Privacy;
 };
 
+type UseAwaitCacheResult<T> = {
+  item: T | null,
+  stored: number,
+  ttl: number,
+};
+
 declare namespace fastifyCaching {
   /**
    * @link [`abstract-cache` protocol documentation](https://github.com/jsumners/abstract-cache#protocol)
@@ -42,11 +48,15 @@ declare namespace fastifyCaching {
   export interface AbstractCacheCompliantObject {
     get<T = unknown>(
       key: string | { id: string; segment: string },
-      callback: (error: unknown, result: (T | undefined)) => void
+      callback: (error: unknown, result: UseAwaitCacheResult<T>) => void
     ): void;
+    /**
+     * If AbstractCache is using useAwait = true, then this method-header must be used.
+     * @param key 
+     */
     get<T = unknown>(
       key: string | { id: string; segment: string },
-    ): (T | undefined);
+    ): Promise<UseAwaitCacheResult<T>>;
     set(
       key: string | { id: string; segment: string },
       value: unknown,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -40,10 +40,13 @@ declare namespace fastifyCaching {
    * @link [`abstract-cache` protocol documentation](https://github.com/jsumners/abstract-cache#protocol)
    */
   export interface AbstractCacheCompliantObject {
-    get(
+    get<T = unknown>(
       key: string | { id: string; segment: string },
-      callback?: (error: unknown, result: unknown) => void
+      callback: (error: unknown, result: (T | undefined)) => void
     ): void;
+    get<T = unknown>(
+      key: string | { id: string; segment: string },
+    ): (T | undefined);
     set(
       key: string | { id: string; segment: string },
       value: unknown,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -35,11 +35,11 @@ type FastifyCaching = FastifyPluginCallback<fastifyCaching.FastifyCachingPluginO
   privacy: fastifyCaching.Privacy;
 };
 
-type UseAwaitCacheResult<T> = {
-  item: T | null,
+type CacheResult<T> = {
+  item: T,
   stored: number,
   ttl: number,
-};
+} | null;
 
 declare namespace fastifyCaching {
   /**
@@ -48,7 +48,7 @@ declare namespace fastifyCaching {
   export interface AbstractCacheCompliantObject {
     get<T = unknown>(
       key: string | { id: string; segment: string },
-      callback: (error: unknown, result: UseAwaitCacheResult<T>) => void
+      callback: (error: unknown, result: CacheResult<T>) => void
     ): void;
     /**
      * If AbstractCache is using useAwait = true, then this method-header must be used.
@@ -56,7 +56,7 @@ declare namespace fastifyCaching {
      */
     get<T = unknown>(
       key: string | { id: string; segment: string },
-    ): Promise<UseAwaitCacheResult<T>>;
+    ): Promise<CacheResult<T>>;
     set(
       key: string | { id: string; segment: string },
       value: unknown,

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -55,13 +55,13 @@ fastify.get('/three', async (request, reply) => {
   expectType<unknown>(
     fastify.cache.get('well-known')
   );
-  expectType<string|undefined>(
+  expectAssignable<Promise<{ item: string | null; stored: number; ttl: number; }>>(
     fastify.cache.get<string>('well-known')
   );
   expectType<void>(
     fastify.cache.get<string>('well-known', (err, value) => {
       expectType<unknown>(err);
-      expectType<string|undefined>(value);
+      expectAssignable<{ item: string | null; stored: number; ttl: number; }>(value);
     })
   );
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -52,7 +52,7 @@ const badCachingOptions = {
 expectError(shouldErrorApp.register(fastifyCaching, badCachingOptions));
 
 fastify.get('/three', async (request, reply) => {
-  expectType<unknown>(
+  expectAssignable<Promise<unknown>>(
     fastify.cache.get('well-known')
   );
   expectAssignable<Promise<{ item: string; stored: number; ttl: number; } | null>>(

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -55,13 +55,13 @@ fastify.get('/three', async (request, reply) => {
   expectType<unknown>(
     fastify.cache.get('well-known')
   );
-  expectAssignable<Promise<{ item: string | null; stored: number; ttl: number; }>>(
+  expectAssignable<Promise<{ item: string; stored: number; ttl: number; } | null>>(
     fastify.cache.get<string>('well-known')
   );
   expectType<void>(
     fastify.cache.get<string>('well-known', (err, value) => {
       expectType<unknown>(err);
-      expectAssignable<{ item: string | null; stored: number; ttl: number; }>(value);
+      expectAssignable<{ item: string; stored: number; ttl: number; } | null>(value);
     })
   );
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -50,3 +50,20 @@ const badCachingOptions = {
 };
 
 expectError(shouldErrorApp.register(fastifyCaching, badCachingOptions));
+
+fastify.get('/three', async (request, reply) => {
+  expectType<unknown>(
+    fastify.cache.get('well-known')
+  );
+  expectType<string|undefined>(
+    fastify.cache.get<string>('well-known')
+  );
+  expectType<void>(
+    fastify.cache.get<string>('well-known', (err, value) => {
+      expectType<unknown>(err);
+      expectType<string|undefined>(value);
+    })
+  );
+
+  return { message: 'two' };
+});


### PR DESCRIPTION
Resolves #132 

Question is, if a non callback `.get()` is returning a promise. 
I also assumed that if the key has no value it returns undefined.

Before merging it would be good to clear this.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
