### PR TITLE
fix(types): option privacy in Nodenext | Node16

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -52,7 +52,7 @@ declare namespace fastifyCaching {
     ): void;
     /**
      * If AbstractCache is using useAwait = true, then this method-header must be used.
-     * @param key 
+     * @param key
      */
     get<T = unknown>(
       key: string | { id: string; segment: string },
@@ -130,9 +130,8 @@ declare namespace fastifyCaching {
     serverExpiresIn?: number;
   }
 
-  export const privacy: {
-    privacy: Privacy;
-  };
+  export const privacy: Privacy;
+
   export const fastifyCaching: FastifyCaching;
   export { fastifyCaching as default };
 }


### PR DESCRIPTION
Relate commit [#116](https://github.com/fastify/fastify-caching/pull/116)

When use with typescript in compilerOptions: `"module": "Node16"` | `"Nodenext"`, it will call the `namespace fastifyCaching`, that caused
![image](https://github.com/fastify/fastify-caching/assets/74761884/41b8caa5-7e38-4e2e-852c-b871d936bd9a) 
and should use
![image](https://github.com/fastify/fastify-caching/assets/74761884/059cecae-f158-497c-9971-f64c06e0ed22)

I don`t know why those tests-suits fail.

#### Checklist
- [ ] run npm run test and npm run benchmark
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md?rgh-link-date=2023-12-07T15%3A24%3A49Z#developers-certificate-of-origin-11)
and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md?rgh-link-date=2023-12-07T15%3A24%3A49Z)

### Reproduction
- [Stackblitz](https://stackblitz.com/edit/stackblitz-starters-cw4wqh?file=index.ts)