### PR TITLE
Fixed 'ERR value is not an integer or out of range' issue

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -75,7 +75,7 @@ fastify
   .register(require('@fastify/caching'), {cache: abcache})
 
 fastify.get('/', (req, reply) => {
-  fastify.cache.set('hello', {hello: 'world'}, 10000, (err) => {
+  fastify.cache.set('hello', {hello: 'world'}, '10000', (err) => {
     if (err) return reply.send(err)
     reply.send({hello: 'world'})
   })

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function etag (value, lifetime) {
 function etagHandleRequest (req, res, next) {
   if (!req.headers['if-none-match']) return next()
   const etag = req.headers['if-none-match']
-  this.cache.get({ id: etag, segment: this.cacheSegment }, (err, cached) => {
+  this.cache.get({ id: etag, segment: this.cacheSegment.toString() }, (err, cached) => {
     if (err) return next(err)
     if (cached?.item) {
       return res.status(304).send()

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function etagOnSend (req, res, payload, next) {
   const etag = res.getHeader('etag')
   if (!etag || !res._etagLife) return next()
   this.cache.set(
-    { id: etag, segment: this.cacheSegment },
+    { id: etag, segment: this.cacheSegment.toString() },
     true,
     res._etagLife,
     (err) => next(err, payload)


### PR DESCRIPTION
As described in this issue https://github.com/redis/node-redis/issues/1505 in the comments, the ttl must be a string and must not be an integer.  If you would use an integer you would get the following error: `ReplyError: ERR value is not an integer or out of range` or it would set nothing into the Redis Database.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] documentation is changed or added
- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
