### PR TITLE
chore: migrate from tap to node:test and c8

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,2 +1,0 @@
-files:
-  - test/**/*.test.js

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@fastify/pre-commit": "^2.1.0",
     "@types/node": "^22.0.0",
+    "c8": "^10.1.2",
     "fastify": "^5.0.0-alpha.3",
     "snazzy": "^9.0.0",
     "standard": "^17.1.0",
@@ -43,7 +44,6 @@
   },
   "dependencies": {
     "abstract-cache": "^1.0.1",
-    "c8": "^10.1.2",
     "fastify-plugin": "^5.0.0-pre.fv5.1",
     "uid-safe": "^2.1.5"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "standard --verbose --fix | snazzy",
     "test": "npm run test:unit && npm run test:typescript",
     "test:typescript": "tsd",
-    "test:unit": "tap",
+    "test:unit": "c8 --100 node --test",
     "test:unit:report": "npm run test:unit -- --coverage-report=html",
     "test:unit:verbose": "npm run test:unit -- -Rspec"
   },
@@ -39,11 +39,11 @@
     "fastify": "^5.0.0-alpha.3",
     "snazzy": "^9.0.0",
     "standard": "^17.1.0",
-    "tap": "^18.7.0",
     "tsd": "^0.31.0"
   },
   "dependencies": {
     "abstract-cache": "^1.0.1",
+    "c8": "^10.1.2",
     "fastify-plugin": "^5.0.0-pre.fv5.1",
     "uid-safe": "^2.1.5"
   },

--- a/test/headers.test.js
+++ b/test/headers.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const Fastify = require('fastify')
 const plugin = require('..')
 
@@ -11,7 +11,7 @@ test('decorators get added', async (t) => {
   await fastify.register(plugin)
 
   fastify.get('/', (req, reply) => {
-    t.ok(reply.etag)
+    t.assert.ok(reply.etag)
     reply.send()
   })
 
@@ -32,9 +32,7 @@ test('decorators add headers', async (t) => {
   await fastify.register(plugin)
 
   fastify.get('/', (req, reply) => {
-    reply
-      .etag(tag)
-      .send()
+    reply.etag(tag).send()
   })
 
   await fastify.ready()
@@ -43,8 +41,8 @@ test('decorators add headers', async (t) => {
     method: 'GET',
     path: '/'
   })
-  t.ok(response.headers.etag)
-  t.equal(response.headers.etag, tag)
+  t.assert.ok(response.headers.etag)
+  t.assert.strictEqual(response.headers.etag, tag)
 })
 
 test('sets etag header for falsy argument', async (t) => {
@@ -54,9 +52,7 @@ test('sets etag header for falsy argument', async (t) => {
   await fastify.register(plugin)
 
   fastify.get('/', (req, reply) => {
-    reply
-      .etag()
-      .send()
+    reply.etag().send()
   })
 
   await fastify.ready()
@@ -65,7 +61,7 @@ test('sets etag header for falsy argument', async (t) => {
     method: 'GET',
     path: '/'
   })
-  t.ok(response.headers.etag)
+  t.assert.ok(response.headers.etag)
 })
 
 test('sets no-cache header', async (t) => {
@@ -84,8 +80,8 @@ test('sets no-cache header', async (t) => {
     method: 'GET',
     path: '/'
   })
-  t.ok(response.headers['cache-control'])
-  t.equal(response.headers['cache-control'], 'no-cache')
+  t.assert.ok(response.headers['cache-control'])
+  t.assert.strictEqual(response.headers['cache-control'], 'no-cache')
 })
 
 test('sets private with max-age header', async (t) => {
@@ -109,8 +105,11 @@ test('sets private with max-age header', async (t) => {
     method: 'GET',
     path: '/'
   })
-  t.ok(response.headers['cache-control'])
-  t.equal(response.headers['cache-control'], 'private, max-age=300')
+  t.assert.ok(response.headers['cache-control'])
+  t.assert.strictEqual(
+    response.headers['cache-control'],
+    'private, max-age=300'
+  )
 })
 
 test('sets public with max-age and s-maxage header', async (t) => {
@@ -135,8 +134,11 @@ test('sets public with max-age and s-maxage header', async (t) => {
     method: 'GET',
     path: '/'
   })
-  t.ok(response.headers['cache-control'])
-  t.equal(response.headers['cache-control'], 'public, max-age=300, s-maxage=12345')
+  t.assert.ok(response.headers['cache-control'])
+  t.assert.strictEqual(
+    response.headers['cache-control'],
+    'public, max-age=300, s-maxage=12345'
+  )
 })
 
 test('do not set headers if another upstream plugin already sets it', async (t) => {
@@ -164,8 +166,8 @@ test('do not set headers if another upstream plugin already sets it', async (t) 
     method: 'GET',
     path: '/'
   })
-  t.ok(response.headers['cache-control'])
-  t.equal(response.headers['cache-control'], 'do not override')
+  t.assert.ok(response.headers['cache-control'])
+  t.assert.strictEqual(response.headers['cache-control'], 'do not override')
 })
 
 test('only sets max-age and ignores s-maxage with private header', async (t) => {
@@ -190,8 +192,11 @@ test('only sets max-age and ignores s-maxage with private header', async (t) => 
     method: 'GET',
     path: '/'
   })
-  t.ok(response.headers['cache-control'])
-  t.equal(response.headers['cache-control'], 'private, max-age=300')
+  t.assert.ok(response.headers['cache-control'])
+  t.assert.strictEqual(
+    response.headers['cache-control'],
+    'private, max-age=300'
+  )
 })
 
 test('s-maxage is optional with public header', async (t) => {
@@ -215,8 +220,8 @@ test('s-maxage is optional with public header', async (t) => {
     method: 'GET',
     path: '/'
   })
-  t.ok(response.headers['cache-control'])
-  t.equal(response.headers['cache-control'], 'public, max-age=300')
+  t.assert.ok(response.headers['cache-control'])
+  t.assert.strictEqual(response.headers['cache-control'], 'public, max-age=300')
 })
 
 test('sets no-store with max-age header', async (t) => {
@@ -235,8 +240,11 @@ test('sets no-store with max-age header', async (t) => {
     method: 'GET',
     path: '/'
   })
-  t.ok(response.headers['cache-control'])
-  t.equal(response.headers['cache-control'], 'no-store, max-age=300')
+  t.assert.ok(response.headers['cache-control'])
+  t.assert.strictEqual(
+    response.headers['cache-control'],
+    'no-store, max-age=300'
+  )
 })
 
 test('sets the expires header', async (t) => {
@@ -248,9 +256,7 @@ test('sets the expires header', async (t) => {
   await fastify.register(plugin, { privacy: plugin.privacy.NOCACHE })
 
   fastify.get('/', (req, reply) => {
-    reply
-      .expires(now)
-      .send({ hello: 'world' })
+    reply.expires(now).send({ hello: 'world' })
   })
 
   await fastify.ready()
@@ -259,8 +265,8 @@ test('sets the expires header', async (t) => {
     method: 'GET',
     path: '/'
   })
-  t.ok(response.headers.expires)
-  t.equal(response.headers.expires, now.toUTCString())
+  t.assert.ok(response.headers.expires)
+  t.assert.strictEqual(response.headers.expires, now.toUTCString())
 })
 
 test('sets the expires header to a falsy value', async (t) => {
@@ -270,9 +276,7 @@ test('sets the expires header to a falsy value', async (t) => {
   await fastify.register(plugin, { privacy: plugin.privacy.NOCACHE })
 
   fastify.get('/', (req, reply) => {
-    reply
-      .expires()
-      .send({ hello: 'world' })
+    reply.expires().send({ hello: 'world' })
   })
 
   await fastify.ready()
@@ -281,7 +285,7 @@ test('sets the expires header to a falsy value', async (t) => {
     method: 'GET',
     path: '/'
   })
-  t.notOk(response.headers.expires)
+  t.assert.ifError(response.headers.expires)
 })
 
 test('sets the expires header to a custom value', async (t) => {
@@ -291,9 +295,7 @@ test('sets the expires header to a custom value', async (t) => {
   await fastify.register(plugin, { privacy: plugin.privacy.NOCACHE })
 
   fastify.get('/', (req, reply) => {
-    reply
-      .expires('foobar')
-      .send({ hello: 'world' })
+    reply.expires('foobar').send({ hello: 'world' })
   })
 
   await fastify.ready()
@@ -302,6 +304,6 @@ test('sets the expires header to a custom value', async (t) => {
     method: 'GET',
     path: '/'
   })
-  t.ok(response.headers.expires)
-  t.equal(response.headers.expires, 'foobar')
+  t.assert.ok(response.headers.expires)
+  t.assert.strictEqual(response.headers.expires, 'foobar')
 })


### PR DESCRIPTION
#### Checklist

This PR migrates from `tap` to `node:test` and `c8`

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
