### PR TITLE
fix: do not cache non-2xx responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,9 +70,16 @@ function fastifyCaching (instance, options, next) {
       value += `, s-maxage=${_options.serverExpiresIn}`
     }
 
-    instance.addHook('onRequest', function cachingSetCacheControlHeader (_req, res, next) {
-      if (!res.hasHeader('Cache-control')) {
-        res.header('Cache-control', value)
+    instance.addHook('onSend', function cachingSetCacheControlHeader (_req, reply, _payload, next) {
+      if (!reply.hasHeader('Cache-control')) {
+        // Only apply the caching value to successful (2xx) responses.
+        // Error responses must not be cached, otherwise browsers may serve
+        // a stale 4xx/5xx for the duration of max-age.
+        if (reply.statusCode >= 200 && reply.statusCode < 300) {
+          reply.header('Cache-control', value)
+        } else {
+          reply.header('Cache-control', 'no-store')
+        }
       }
       next()
     })

--- a/test/headers.test.js
+++ b/test/headers.test.js
@@ -247,6 +247,105 @@ test('sets no-store with max-age header', async (t) => {
   )
 })
 
+test('does not cache 5xx error responses', async (t) => {
+  t.plan(2)
+
+  const opts = {
+    privacy: plugin.privacy.PRIVATE,
+    expiresIn: 300
+  }
+
+  const fastify = Fastify()
+  await fastify.register(plugin, opts)
+
+  fastify.get('/', () => {
+    throw new Error('kaboom')
+  })
+
+  await fastify.ready()
+
+  const response = await fastify.inject({
+    method: 'GET',
+    path: '/'
+  })
+  t.assert.strictEqual(response.statusCode, 500)
+  t.assert.strictEqual(response.headers['cache-control'], 'no-store')
+})
+
+test('does not cache 4xx error responses', async (t) => {
+  t.plan(2)
+
+  const opts = {
+    privacy: plugin.privacy.PRIVATE,
+    expiresIn: 300
+  }
+
+  const fastify = Fastify()
+  await fastify.register(plugin, opts)
+
+  fastify.get('/', (_req, reply) => {
+    reply.code(400).send({ error: 'bad request' })
+  })
+
+  await fastify.ready()
+
+  const response = await fastify.inject({
+    method: 'GET',
+    path: '/'
+  })
+  t.assert.strictEqual(response.statusCode, 400)
+  t.assert.strictEqual(response.headers['cache-control'], 'no-store')
+})
+
+test('does not cache framework 404 responses', async (t) => {
+  t.plan(2)
+
+  const opts = {
+    privacy: plugin.privacy.PRIVATE,
+    expiresIn: 300
+  }
+
+  const fastify = Fastify()
+  await fastify.register(plugin, opts)
+
+  await fastify.ready()
+
+  const response = await fastify.inject({
+    method: 'GET',
+    path: '/does-not-exist'
+  })
+  t.assert.strictEqual(response.statusCode, 404)
+  t.assert.strictEqual(response.headers['cache-control'], 'no-store')
+})
+
+test('does not override a Cache-control header set upstream on error responses', async (t) => {
+  t.plan(2)
+
+  const opts = {
+    privacy: plugin.privacy.PRIVATE,
+    expiresIn: 300
+  }
+
+  const fastify = Fastify()
+  fastify.addHook('onRequest', async function presetCacheControl (_req, reply) {
+    reply.header('cache-control', 'private, max-age=10')
+  })
+  await fastify.register(plugin, opts)
+
+  fastify.get('/', () => {
+    throw new Error('kaboom')
+  })
+
+  await fastify.ready()
+
+  const response = await fastify.inject({
+    method: 'GET',
+    path: '/'
+  })
+  t.assert.strictEqual(response.statusCode, 500)
+  t.assert.strictEqual(response.headers['cache-control'], 'private, max-age=10')
+})
+
 test('sets the expires header', async (t) => {
   t.plan(2)
 


### PR DESCRIPTION
The `Cache-control` header was applied in an `onRequest` hook, before the status code is known, so 4xx/5xx errors were sent with `max-age` and cached. Moves the logic to `onSend`: 2xx keep the computed value, non-2xx get `no-store`; preserves the existing user-set-header guard.

Closes #182