### PR TITLE
docs: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 *@fastify/caching* is a plugin for the [Fastify](https://fastify.dev/) framework
 that provides server-side caching and mechanisms for manipulating HTTP cache headers according to
-[RFC 2616 §14.9](https://tools.ietf.org/html/rfc2616#section-14.9).
+[RFC 2616 §14.9](https://datatracker.ietf.org/doc/html/rfc2616#section-14.9).
 
 This plugin fully supports Fastify's encapsulation. Therefore, routes that
 should have differing cache settings should be registered within different
@@ -161,7 +161,7 @@ This method allows setting of the `expires` header. It accepts a regular `Date`
 object or a string that is a valid date string according to
 [RFC 2616 §14.21][sec14.21].
 
-[sec14.21]: https://tools.ietf.org/html/rfc2616#section-14.21
+[sec14.21]: https://datatracker.ietf.org/doc/html/rfc2616#section-14.21
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ function fastifyCaching (instance, options, next) {
   if (!_options.cache) _options.cache = abstractCache()
 
   if (_options.privacy) {
-    // https://tools.ietf.org/html/rfc2616#section-14.9.4
+    // https://datatracker.ietf.org/doc/html/rfc2616#section-14.9.4
     let value = _options.privacy
     if (_options.privacy.toLowerCase() !== 'no-cache' && _options.expiresIn) {
       value = `${_options.privacy}, max-age=${_options.expiresIn}`


### PR DESCRIPTION
Fixes 404s, 3xx redirections, and missing fragments in the documentation. Part of general link cleanup being tracked in https://github.com/fastify/accept-negotiator/pull/71